### PR TITLE
Add `--replace` as an alternative to `--output`

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -35,6 +35,14 @@ function options(flags, configuration) {
     }
   })
 
+  if (config.replace && config.output) {
+    throw fault('`--replace` and `--output` can not be used together')
+  }
+
+  if (config.replace) {
+    config.output = true
+  }
+
   ext = extensions(config.ext)
   report = reporter(config.report)
 

--- a/lib/schema.json
+++ b/lib/schema.json
@@ -20,6 +20,13 @@
     "value": "[path]"
   },
   {
+    "long": "replace",
+    "description": "fix and replace file(s)",
+    "short": "p",
+    "type": "boolean",
+    "default": false
+  },
+  {
     "long": "rc-path",
     "description": "specify configuration file",
     "short": "r",

--- a/test/fixtures/example/HELP
+++ b/test/fixtures/example/HELP
@@ -7,6 +7,7 @@ Options:
   -h  --help                output usage information
   -v  --version             output version number
   -o  --output [path]       specify output location
+  -p  --replace             fix and replace file(s)
   -r  --rc-path <path>      specify configuration file
   -i  --ignore-path <path>  specify ignore file
   -s  --setting <settings>  specify settings

--- a/test/fixtures/example/LONG_FLAG
+++ b/test/fixtures/example/LONG_FLAG
@@ -2,6 +2,7 @@ Error: Unknown option `--no`, expected:
   -h  --help                output usage information
   -v  --version             output version number
   -o  --output [path]       specify output location
+  -p  --replace             fix and replace file(s)
   -r  --rc-path <path>      specify configuration file
   -i  --ignore-path <path>  specify ignore file
   -s  --setting <settings>  specify settings

--- a/test/fixtures/example/SHORT_FLAG
+++ b/test/fixtures/example/SHORT_FLAG
@@ -2,6 +2,7 @@ Error: Unknown short option `-n`, expected:
   -h  --help                output usage information
   -v  --version             output version number
   -o  --output [path]       specify output location
+  -p  --replace             fix and replace file(s)
   -r  --rc-path <path>      specify configuration file
   -i  --ignore-path <path>  specify ignore file
   -s  --setting <settings>  specify settings

--- a/test/index.js
+++ b/test/index.js
@@ -554,5 +554,17 @@ test('unified-args', function(t) {
     }
   })
 
+  t.test('should fail when both replace and output are set', function(st) {
+    var bin = join(fixtures, 'uncaught-errors', 'cli.js')
+    var expected =
+      'Error: `--replace` and `--output` can not be used together\n'
+
+    execa(bin, ['.', '--replace', '--output']).then(st.fail, onfail)
+
+    function onfail(res) {
+      st.deepEqual([res.code, strip(res.stderr)], [1, expected], 'should fail')
+    }
+  })
+
   t.end()
 })


### PR DESCRIPTION
Why?
To use `--output` to replace all files, we can not pass any path after.
Since `--output` is a flexible option where it might have `[path]` parameter,
means that depending on where this option is used, it can be an argument or a
flag which leads to different results, example (with [`remark`](https://github.com/remarkjs/remark/)):

```bash
# `--output` positioned before the path fails
$ remark --output README.md
Error: No input
    at stdin /path/to/test/node_modules/unified-engine/lib/file-set-pipeline/stdin.js:29:10)
    at wrapped /path/to/test/node_modules/trough/wrap.js:25:19)
    at next /path/to/test/node_modules/trough/index.js:58:24)
    at done /path/to/test/node_modules/trough/wrap.js:56:16)
    at fileSystem /path/to/test/node_modules/unified-engine/lib/file-set-pipeline/file-system.js:13:5)
    at wrapped /path/to/test/node_modules/trough/wrap.js:25:19)
    at next /path/to/test/node_modules/trough/index.js:58:24)
    at done /path/to/test/node_modules/trough/wrap.js:56:16)
    at then /path/to/test/node_modules/trough/wrap.js:63:5)
    at wrapped /path/to/test/node_modules/trough/wrap.js:46:9)

# `--output` positioned after the path works as expected
$ remark README.md --output
README.md: written
```

The behavior above becomes an issue for tools that do not expect to position to
matter, which is the case with [lint-staged](https://github.com/okonet/lint-staged).

<img width="983" alt="screenshot 2019-01-19 at 12 56 49" src="https://user-images.githubusercontent.com/3427665/51427676-f6543b00-1bfa-11e9-99c1-8c62b1f454c0.png">
