### PR TITLE
Add `--silently-ignore`

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -79,6 +79,7 @@ function options(flags, configuration) {
     ignorePath: config.ignorePath,
     ignorePathResolveFrom: config.ignorePathResolveFrom,
     ignorePatterns: commaSeparated(config.ignorePattern),
+    silentlyIgnore: config.silentlyIgnore,
     detectIgnore: config.ignore,
     pluginPrefix: configuration.pluginPrefix,
     plugins: plugins(config.use),

--- a/lib/schema.json
+++ b/lib/schema.json
@@ -130,6 +130,11 @@
     "type": "boolean"
   },
   {
+    "long": "silently-ignore",
+    "description": "suppress warnings about given ignored files",
+    "type": "boolean"
+  },
+  {
     "long": "stdout",
     "description": "specify writing to stdout",
     "type": "boolean",

--- a/test/fixtures/example/HELP
+++ b/test/fixtures/example/HELP
@@ -24,6 +24,7 @@ Options:
       --tree-in                           specify input as syntax tree
       --tree-out                          output syntax tree
       --inspect                           output formatted syntax tree
+      --silently-ignore                   suppress warnings about given ignored files
       --[no-]stdout                       specify writing to stdout (on by default)
       --[no-]color                        specify color in report (on by default)
       --[no-]config                       search for configuration files (on by default)

--- a/test/fixtures/example/LONG_FLAG
+++ b/test/fixtures/example/LONG_FLAG
@@ -19,6 +19,7 @@ Error: Unknown option `--no`, expected:
       --tree-in                           specify input as syntax tree
       --tree-out                          output syntax tree
       --inspect                           output formatted syntax tree
+      --silently-ignore                   suppress warnings about given ignored files
       --[no-]stdout                       specify writing to stdout (on by default)
       --[no-]color                        specify color in report (on by default)
       --[no-]config                       search for configuration files (on by default)

--- a/test/index.js
+++ b/test/index.js
@@ -566,6 +566,52 @@ test('unified-args', function (t) {
     }
   })
 
+  t.test('should fail when given an ignored path', function (t) {
+    var expected = [
+      'one.txt',
+      '  1:1  error  Cannot process specified file: it’s ignored',
+      '',
+      'two.txt: no issues found',
+      '',
+      figures.cross + ' 1 error'
+    ].join('\n')
+
+    t.plan(1)
+
+    execa(bin, ['one.txt', 'two.txt', '--ignore-pattern', 'one.txt']).then(
+      t.fail,
+      onfail
+    )
+
+    function onfail(result) {
+      t.deepEqual(
+        [result.exitCode, strip(result.stderr)],
+        [1, expected],
+        'should fail'
+      )
+    }
+  })
+
+  t.test('should support `--silently-ignore`', function (t) {
+    t.plan(1)
+
+    execa(bin, [
+      'one.txt',
+      'two.txt',
+      '--ignore-pattern',
+      'one.txt',
+      '--silently-ignore'
+    ]).then(onsuccess, t.fail)
+
+    function onsuccess(result) {
+      t.deepEqual(
+        [result.stdout, strip(result.stderr)],
+        ['', 'two.txt: no issues found'],
+        'should work'
+      )
+    }
+  })
+
   t.test('should honour `--watch`', function (t) {
     var expected = [
       'Watching... (press CTRL+C to exit)',


### PR DESCRIPTION
`silentlyIgnore` has been available in unified-engine for a while, but it wasn't exposed to unified-args. this change adds `--silently-ignore` and some tests to go with it