### PR TITLE
Update sentence structure in line 290 of readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -288,7 +288,7 @@ Configuration for the parser and compiler of the processor.
 Can be set from [configuration files][config-file].
 
 The given settings are [JSON5][], with one exception: surrounding braces must
-not be used.  Instead, simply use JSON syntax without braces, i.e. `"foo": 1, "bar": "baz"`.
+not be used.  Instead, use JSON syntax without braces, such as `"foo": 1, "bar": "baz"`.
 
 *   **Default**: none
 *   **Alias**: `-s`

--- a/readme.md
+++ b/readme.md
@@ -288,7 +288,7 @@ Configuration for the parser and compiler of the processor.
 Can be set from [configuration files][config-file].
 
 The given settings are [JSON5][], with one exception: surrounding braces must
-not be used: `"foo": 1, "bar": "baz"` is valid
+not be used. Instead, simply use JSON syntax without braces, i.e. `"foo": 1, "bar": "baz"`.
 
 *   **Default**: none
 *   **Alias**: `-s`

--- a/readme.md
+++ b/readme.md
@@ -288,7 +288,7 @@ Configuration for the parser and compiler of the processor.
 Can be set from [configuration files][config-file].
 
 The given settings are [JSON5][], with one exception: surrounding braces must
-not be used. Instead, simply use JSON syntax without braces, i.e. `"foo": 1, "bar": "baz"`.
+not be used.  Instead, simply use JSON syntax without braces, i.e. `"foo": 1, "bar": "baz"`.
 
 *   **Default**: none
 *   **Alias**: `-s`

--- a/readme.md
+++ b/readme.md
@@ -287,7 +287,7 @@ cli input.txt --setting 'golf: false, hotel-india: ["juliet", 1]'
 Configuration for the parser and compiler of the processor.
 Can be set from [configuration files][config-file].
 
-The given settings are [JSON5][], with one exceptions: surrounding braces must
+The given settings are [JSON5][], with one exception: surrounding braces must
 not be used: `"foo": 1, "bar": "baz"` is valid
 
 *   **Default**: none


### PR DESCRIPTION
## Description

I made a couple of changes to improve readability on line 290 of `readme.md`.

1. changed "one exceptions" to "one exception"
2. Broke up long sentence with multiple colons into two sentences, elaborated a bit about inability to use braces in JSON5 format to hopefully make things more clear